### PR TITLE
The user paperless cannot access /etc/paperless.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,8 @@
   template:
     src: "{{ paperless_configuration_template }}"
     dest: /etc/paperless.conf
+    owner: paperless
+    mode: g+r
   notify: Restart Paperless
 
 - name: Migrate Database


### PR DESCRIPTION
Required for modern ansible versions to ensure that the daemons can actually access the config file